### PR TITLE
Cleanups and modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ composer require j0k3r/httplug-ssrf-plugin
 ```php
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\ServerSideRequestForgeryProtectionPlugin;
 use Http\Client\Common\PluginClient;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 
 $ssrfPlugin = new ServerSideRequestForgeryProtectionPlugin();
 
 $pluginClient = new PluginClient(
-    HttpClientDiscovery::find(),
+    Psr18ClientDiscovery::find(),
     [$ssrfPlugin]
 );
 ```
@@ -43,36 +43,36 @@ Domains are express using regex syntax, whilst IPs, scheme and ports are standar
 ```php
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Options;
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\ServerSideRequestForgeryProtectionPlugin;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Http\Client\Common\PluginClient;
 
 $options = new Options();
 $options->addToList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN, '(.*)\.example\.com');
 
 $pluginClient = new PluginClient(
-    HttpClientDiscovery::find(),
+    Psr18ClientDiscovery::find(),
     [new ServerSideRequestForgeryProtectionPlugin($options)]
 );
 
 // This will throw an Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException\InvalidDomainException
-$request = MessageFactoryDiscovery::find()->createRequest('GET', 'https://www.example.com');
+$request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('GET', 'https://www.example.com');
 $response = $pluginClient->sendRequest($request);
 
 $options = new Options();
 $options->setList(Options::LIST_WHITELIST, [Options::TYPE_SCHEME => ['https']]);
 
 $pluginClient = new PluginClient(
-    HttpClientDiscovery::find(),
+    Psr18ClientDiscovery::find(),
     [new ServerSideRequestForgeryProtectionPlugin($options)]
 );
 
 // This will be allowed, and return the response
-$request = MessageFactoryDiscovery::find()->createRequest('GET', 'https://www.example.com');
+$request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('GET', 'https://www.example.com');
 $response = $pluginClient->sendRequest($request);
 
 // This will throw an Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException\InvalidDomainException
-$request = MessageFactoryDiscovery::find()->createRequest('GET', 'https://www.example.com');
+$request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('GET', 'https://www.example.com');
 $response = $pluginClient->sendRequest($request);
 ```
 
@@ -92,8 +92,8 @@ The second disables the use of credentials in a URL, since PHP's `parse_url` ret
 ```php
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Options;
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\ServerSideRequestForgeryProtectionPlugin;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Http\Client\Common\PluginClient;
 
 $options = new Options();
@@ -101,10 +101,10 @@ $options->disableSendCredentials();
 
 //This will throw an Http\Client\Exception\RequestException
 $pluginClient = new PluginClient(
-    HttpClientDiscovery::find(),
+    Psr18ClientDiscovery::find(),
     [new ServerSideRequestForgeryProtectionPlugin($options)]
 );
-$request = MessageFactoryDiscovery::find()->createRequest('GET', 'https://user:pass@google.com');
+$request = Psr17FactoryDiscovery::findRequestFactory()->createRequest('GET', 'https://user:pass@google.com');
 $response = $pluginClient->sendRequest($request);
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Http\Client\Common\PluginClient;
 
 $options = new Options();
-$options->addToList('blacklist', 'domain', '(.*)\.example\.com');
+$options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.example\.com');
 
 $pluginClient = new PluginClient(
     HttpClientDiscovery::find(),
@@ -60,7 +60,7 @@ $request = MessageFactoryDiscovery::find()->createRequest('GET', 'https://www.ex
 $response = $pluginClient->sendRequest($request);
 
 $options = new Options();
-$options->setList('whitelist', ['scheme' => ['https']]);
+$options->setList(Options::LIST_WHITELIST, ['scheme' => ['https']]);
 
 $pluginClient = new PluginClient(
     HttpClientDiscovery::find(),

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Http\Client\Common\PluginClient;
 
 $options = new Options();
-$options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.example\.com');
+$options->addToList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN, '(.*)\.example\.com');
 
 $pluginClient = new PluginClient(
     HttpClientDiscovery::find(),
@@ -60,7 +60,7 @@ $request = MessageFactoryDiscovery::find()->createRequest('GET', 'https://www.ex
 $response = $pluginClient->sendRequest($request);
 
 $options = new Options();
-$options->setList(Options::LIST_WHITELIST, ['scheme' => ['https']]);
+$options->setList(Options::LIST_WHITELIST, [Options::TYPE_SCHEME => ['https']]);
 
 $pluginClient = new PluginClient(
     HttpClientDiscovery::find(),

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require": {
         "php": ">=7.4",
         "php-http/client-common": "^2.6",
+        "php-http/discovery": "^1.15",
         "php-http/message": "^1.13",
-        "php-http/message-factory": "^1.0",
-        "php-http/discovery": "^1.15"
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "php-http/client-common": "^2.6",
         "php-http/discovery": "^1.15",
         "php-http/message": "^1.13",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",
+        "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/psr7": "^2.0",
         "php-http/guzzle7-adapter": "^1.0",
-        "php-http/mock-client": "^1.5",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",
-        "guzzlehttp/psr7": "^1.9",
-        "php-http/guzzle6-adapter": "^2.0",
+        "guzzlehttp/psr7": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "php-http/mock-client": "^1.5",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.10",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: max
     paths:
         - src
         - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,3 +13,6 @@ parameters:
     ignoreErrors:
         # Fix PHPUnit\Framework\TestCase::expectException() custom typehint
         - '#class\-string\<Throwable\>#'
+
+        # Tests try to pass invalid value since PHPDoc annotation cannot really enforce it.
+        - '(expects array\|int\|string, object\{dummy: bool\}&stdClass given\.)'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,3 +16,4 @@ parameters:
 
         # Tests try to pass invalid value since PHPDoc annotation cannot really enforce it.
         - '(expects array\|int\|string, object\{dummy: bool\}&stdClass given\.)'
+        - '(expects .blacklist.\|.whitelist., .noo. given\.)'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,5 @@ parameters:
         # Tests try to pass invalid value since PHPDoc annotation cannot really enforce it.
         - '(expects array\|int\|string, object\{dummy: bool\}&stdClass given\.)'
         - '(expects .blacklist.\|.whitelist., .noo. given\.)'
+        - '(expects .domain.\|.ip.\|.port.\|.scheme., .noo. given\.)'
+        - '(expects .domain.\|.ip.\|.port.\|.scheme.\|null, .noo. given\.)'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,15 +7,12 @@ parameters:
     bootstrapFiles:
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
 
-    inferPrivatePropertyTypeFromConstructor: true
-    checkMissingIterableValueType: false
-
     ignoreErrors:
         # Fix PHPUnit\Framework\TestCase::expectException() custom typehint
         - '#class\-string\<Throwable\>#'
 
         # Tests try to pass invalid value since PHPDoc annotation cannot really enforce it.
-        - '(expects array\|int\|string, object\{dummy: bool\}&stdClass given\.)'
+        - '(expects array<int\|string>\|int\|string, object\{dummy: bool\}&stdClass given\.)'
         - '(expects .blacklist.\|.whitelist., .noo. given\.)'
         - '(expects .domain.\|.ip.\|.port.\|.scheme., .noo. given\.)'
         - '(expects .domain.\|.ip.\|.port.\|.scheme.\|null, .noo. given\.)'

--- a/src/Exception/InvalidOptionException.php
+++ b/src/Exception/InvalidOptionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception;
 
 final class InvalidOptionException extends \Exception implements SsrfException

--- a/src/Exception/InvalidOptionException.php
+++ b/src/Exception/InvalidOptionException.php
@@ -5,11 +5,11 @@ namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception;
 final class InvalidOptionException extends \Exception implements SsrfException
 {
     /**
-     * @param string $type
+     * @param string[] $expectedTypes
      *
      * @return static
      */
-    public static function invalidType($type, array $expectedTypes): self
+    public static function invalidType(string $type, array $expectedTypes): self
     {
         $expectedTypesList = '"' . implode('", "', \array_slice($expectedTypes, 0, -1))
             . '" or "' . $expectedTypes[\count($expectedTypes) - 1] . '"';
@@ -18,11 +18,9 @@ final class InvalidOptionException extends \Exception implements SsrfException
     }
 
     /**
-     * @param string $listName
-     *
      * @return static
      */
-    public static function invalidListName($listName): self
+    public static function invalidListName(string $listName): self
     {
         return new static(sprintf('Provided list "%s" must be "whitelist" or "blacklist"', $listName));
     }

--- a/src/Exception/InvalidURLException.php
+++ b/src/Exception/InvalidURLException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception;
 
 class InvalidURLException extends \Exception implements SsrfException

--- a/src/Exception/InvalidURLException/InvalidDomainException.php
+++ b/src/Exception/InvalidURLException/InvalidDomainException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/src/Exception/InvalidURLException/InvalidIPException.php
+++ b/src/Exception/InvalidURLException/InvalidIPException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/src/Exception/InvalidURLException/InvalidPortException.php
+++ b/src/Exception/InvalidURLException/InvalidPortException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/src/Exception/InvalidURLException/InvalidSchemeException.php
+++ b/src/Exception/InvalidURLException/InvalidSchemeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/src/Exception/SsrfException.php
+++ b/src/Exception/SsrfException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception;
 
 interface SsrfException

--- a/src/Options.php
+++ b/src/Options.php
@@ -6,8 +6,7 @@ use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\Invalid
 
 class Options
 {
-    /** @var array */
-    private static $availableType = [
+    private const AVAILABLE_TYPE = [
         'ip',
         'port',
         'domain',
@@ -133,7 +132,7 @@ class Options
         $value = (string) $value;
 
         if (!\array_key_exists($type, $this->lists[$listName])) {
-            throw InvalidOptionException::invalidType($type, self::$availableType);
+            throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
         }
 
         if (empty($this->lists[$listName][$type])) {
@@ -167,7 +166,7 @@ class Options
 
         if (null !== $type) {
             if (!\array_key_exists($type, $this->lists[$listName])) {
-                throw InvalidOptionException::invalidType($type, self::$availableType);
+                throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
             }
 
             return $this->lists[$listName][$type];
@@ -189,7 +188,7 @@ class Options
 
         if (null !== $type) {
             if (!\array_key_exists($type, $this->lists[$listName])) {
-                throw InvalidOptionException::invalidType($type, self::$availableType);
+                throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
             }
 
             if ('port' === $type) {
@@ -201,8 +200,8 @@ class Options
         }
 
         foreach ($values as $type => $value) {
-            if (!\in_array($type, self::$availableType, true)) {
-                throw InvalidOptionException::invalidType($type, self::$availableType);
+            if (!\in_array($type, self::AVAILABLE_TYPE, true)) {
+                throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
             }
 
             if ('port' === $type) {
@@ -227,7 +226,7 @@ class Options
         $this->checkListByName($listName);
 
         if (!\array_key_exists($type, $this->lists[$listName])) {
-            throw InvalidOptionException::invalidType($type, self::$availableType);
+            throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
         }
 
         if (empty($values)) {
@@ -263,7 +262,7 @@ class Options
         $this->checkListByName($listName);
 
         if (!\array_key_exists($type, $this->lists[$listName])) {
-            throw InvalidOptionException::invalidType($type, self::$availableType);
+            throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
         }
 
         if (empty($values)) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidOptionException;

--- a/src/Options.php
+++ b/src/Options.php
@@ -192,6 +192,9 @@ class Options
                 throw InvalidOptionException::invalidType($type, self::$availableType);
             }
 
+            if ('port' === $type) {
+                $values = self::ensureStringList($values);
+            }
             $this->lists[$listName][$type] = $values;
 
             return $this;
@@ -202,6 +205,9 @@ class Options
                 throw InvalidOptionException::invalidType($type, self::$availableType);
             }
 
+            if ('port' === $type) {
+                $value = self::ensureStringList($value);
+            }
             $this->lists[$listName][$type] = $value;
         }
 
@@ -211,8 +217,8 @@ class Options
     /**
      * Adds a value/values to a specific list.
      *
-     * @param string       $listName Accepts 'whitelist' or 'blacklist
-     * @param array|string $values
+     * @param string           $listName Accepts 'whitelist' or 'blacklist
+     * @param array|string|int $values
      *
      * @throws InvalidOptionException
      */
@@ -231,6 +237,10 @@ class Options
         // Cast single values to an array
         $values = (array) $values;
 
+        if ('port' === $type) {
+            $values = self::ensureStringList($values);
+        }
+
         foreach ($values as $value) {
             if (!\in_array($value, $this->lists[$listName][$type], true)) {
                 $this->lists[$listName][$type][] = $value;
@@ -243,8 +253,8 @@ class Options
     /**
      * Removes a value/values from a specific list.
      *
-     * @param string       $listName Accepts 'whitelist' or 'blacklist
-     * @param array|string $values
+     * @param string           $listName Accepts 'whitelist' or 'blacklist
+     * @param array|string|int $values
      *
      * @throws InvalidOptionException
      */
@@ -263,6 +273,10 @@ class Options
         // Cast single values to an array
         $values = (array) $values;
 
+        if ('port' === $type) {
+            $values = self::ensureStringList($values);
+        }
+
         $this->lists[$listName][$type] = array_diff($this->lists[$listName][$type], $values);
 
         return $this;
@@ -278,5 +292,27 @@ class Options
         if (!isset($this->lists[$listName])) {
             throw InvalidOptionException::invalidListName($listName);
         }
+    }
+
+    /**
+     * @param (string|int)[] $values
+     *
+     * @return string[]
+     */
+    private static function ensureStringList(array $values): array
+    {
+        $result = [];
+        foreach ($values as $value) {
+            if (\is_int($value)) {
+                $value = (string) $value;
+            }
+            if (!\is_string($value)) {
+                throw new \TypeError('Option values can only be strings or ints.');
+            }
+
+            $result[] = $value;
+        }
+
+        return $result;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -6,6 +6,9 @@ use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\Invalid
 
 class Options
 {
+    public const LIST_WHITELIST = 'whitelist';
+    public const LIST_BLACKLIST = 'blacklist';
+
     private const AVAILABLE_TYPE = [
         'ip',
         'port',
@@ -122,7 +125,7 @@ class Options
     /**
      * Checks if a specific value is in a list.
      *
-     * @param string $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
      *
      * @throws InvalidOptionException
      */
@@ -136,7 +139,7 @@ class Options
         }
 
         if (empty($this->lists[$listName][$type])) {
-            return 'whitelist' === $listName;
+            return self::LIST_WHITELIST === $listName;
         }
 
         // For domains, a regex match is needed
@@ -156,7 +159,7 @@ class Options
     /**
      * Returns a specific list.
      *
-     * @param string $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
      *
      * @throws InvalidOptionException
      */
@@ -178,7 +181,7 @@ class Options
     /**
      * Sets a list, the values must be passed as an array.
      *
-     * @param string $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
      *
      * @throws InvalidOptionException
      */
@@ -216,7 +219,7 @@ class Options
     /**
      * Adds a value/values to a specific list.
      *
-     * @param string           $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_*     $listName Accepts 'whitelist' or 'blacklist
      * @param array|string|int $values
      *
      * @throws InvalidOptionException
@@ -252,7 +255,7 @@ class Options
     /**
      * Removes a value/values from a specific list.
      *
-     * @param string           $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_*     $listName Accepts 'whitelist' or 'blacklist
      * @param array|string|int $values
      *
      * @throws InvalidOptionException
@@ -282,7 +285,7 @@ class Options
     }
 
     /**
-     * @param string $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
      *
      * @throws InvalidOptionException
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -216,7 +216,7 @@ class Options
      *
      * @throws InvalidOptionException
      */
-    public function addToList(string $listName, string $type, $values = null): self
+    public function addToList(string $listName, string $type, $values): self
     {
         $this->checkListByName($listName);
 
@@ -248,7 +248,7 @@ class Options
      *
      * @throws InvalidOptionException
      */
-    public function removeFromList(string $listName, string $type, $values = null): self
+    public function removeFromList(string $listName, string $type, $values): self
     {
         $this->checkListByName($listName);
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -9,11 +9,16 @@ class Options
     public const LIST_WHITELIST = 'whitelist';
     public const LIST_BLACKLIST = 'blacklist';
 
+    public const TYPE_IP = 'ip';
+    public const TYPE_PORT = 'port';
+    public const TYPE_DOMAIN = 'domain';
+    public const TYPE_SCHEME = 'scheme';
+
     private const AVAILABLE_TYPE = [
-        'ip',
-        'port',
-        'domain',
-        'scheme',
+        self::TYPE_IP,
+        self::TYPE_PORT,
+        self::TYPE_DOMAIN,
+        self::TYPE_SCHEME,
     ];
     /**
      * Allow credentials in a URL.
@@ -126,6 +131,7 @@ class Options
      * Checks if a specific value is in a list.
      *
      * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
+     * @param self::TYPE_* $type
      *
      * @throws InvalidOptionException
      */
@@ -143,7 +149,7 @@ class Options
         }
 
         // For domains, a regex match is needed
-        if ('domain' === $type) {
+        if (self::TYPE_DOMAIN === $type) {
             foreach ($this->lists[$listName][$type] as $domain) {
                 if (preg_match('/^' . $domain . '$/i', $value)) {
                     return true;
@@ -159,7 +165,8 @@ class Options
     /**
      * Returns a specific list.
      *
-     * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_*  $listName Accepts 'whitelist' or 'blacklist
+     * @param ?self::TYPE_* $type
      *
      * @throws InvalidOptionException
      */
@@ -181,11 +188,12 @@ class Options
     /**
      * Sets a list, the values must be passed as an array.
      *
-     * @param self::LIST_* $listName Accepts 'whitelist' or 'blacklist
+     * @param self::LIST_*  $listName Accepts 'whitelist' or 'blacklist
+     * @param ?self::TYPE_* $type
      *
      * @throws InvalidOptionException
      */
-    public function setList(string $listName, array $values, string $type = null): self
+    public function setList(string $listName, array $values, ?string $type = null): self
     {
         $this->checkListByName($listName);
 
@@ -194,7 +202,7 @@ class Options
                 throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
             }
 
-            if ('port' === $type) {
+            if (self::TYPE_PORT === $type) {
                 $values = self::ensureStringList($values);
             }
             $this->lists[$listName][$type] = $values;
@@ -207,7 +215,7 @@ class Options
                 throw InvalidOptionException::invalidType($type, self::AVAILABLE_TYPE);
             }
 
-            if ('port' === $type) {
+            if (self::TYPE_PORT === $type) {
                 $value = self::ensureStringList($value);
             }
             $this->lists[$listName][$type] = $value;
@@ -220,6 +228,7 @@ class Options
      * Adds a value/values to a specific list.
      *
      * @param self::LIST_*     $listName Accepts 'whitelist' or 'blacklist
+     * @param self::TYPE_*     $type
      * @param array|string|int $values
      *
      * @throws InvalidOptionException
@@ -239,7 +248,7 @@ class Options
         // Cast single values to an array
         $values = (array) $values;
 
-        if ('port' === $type) {
+        if (self::TYPE_PORT === $type) {
             $values = self::ensureStringList($values);
         }
 
@@ -256,6 +265,7 @@ class Options
      * Removes a value/values from a specific list.
      *
      * @param self::LIST_*     $listName Accepts 'whitelist' or 'blacklist
+     * @param self::TYPE_*     $type
      * @param array|string|int $values
      *
      * @throws InvalidOptionException
@@ -275,7 +285,7 @@ class Options
         // Cast single values to an array
         $values = (array) $values;
 
-        if ('port' === $type) {
+        if (self::TYPE_PORT === $type) {
             $values = self::ensureStringList($values);
         }
 

--- a/src/ServerSideRequestForgeryProtectionPlugin.php
+++ b/src/ServerSideRequestForgeryProtectionPlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/src/ServerSideRequestForgeryProtectionPlugin.php
+++ b/src/ServerSideRequestForgeryProtectionPlugin.php
@@ -8,10 +8,10 @@ use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\Invalid
 use Http\Client\Common\Plugin;
 use Http\Client\Exception\RequestException;
 use Http\Client\Promise\HttpRejectedPromise;
-use Http\Discovery\UriFactoryDiscovery;
-use Http\Message\UriFactory;
+use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriFactoryInterface;
 
 /**
  * Validates each part of the URL against a white or black list, to help protect against Server-Side Request Forgery
@@ -23,12 +23,12 @@ use Psr\Http\Message\RequestInterface;
 class ServerSideRequestForgeryProtectionPlugin implements Plugin
 {
     private Options $options;
-    private UriFactory $uriFactory;
+    private UriFactoryInterface $uriFactory;
 
-    public function __construct(Options $options = null, UriFactory $uriFactory = null)
+    public function __construct(Options $options = null, UriFactoryInterface $uriFactory = null)
     {
         $this->options = $options ?: new Options();
-        $this->uriFactory = $uriFactory ?: UriFactoryDiscovery::find();
+        $this->uriFactory = $uriFactory ?: Psr17FactoryDiscovery::findUriFactory();
     }
 
     /**

--- a/src/ServerSideRequestForgeryProtectionPlugin.php
+++ b/src/ServerSideRequestForgeryProtectionPlugin.php
@@ -20,8 +20,8 @@ use Psr\Http\Message\RequestInterface;
  */
 class ServerSideRequestForgeryProtectionPlugin implements Plugin
 {
-    private $options;
-    private $uriFactory;
+    private Options $options;
+    private UriFactory $uriFactory;
 
     public function __construct(Options $options = null, UriFactory $uriFactory = null)
     {
@@ -29,6 +29,10 @@ class ServerSideRequestForgeryProtectionPlugin implements Plugin
         $this->uriFactory = $uriFactory ?: UriFactoryDiscovery::find();
     }
 
+    /**
+     * @param callable(RequestInterface): Promise $next
+     * @param callable(RequestInterface): Promise $first
+     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         try {

--- a/src/Url.php
+++ b/src/Url.php
@@ -85,11 +85,11 @@ class Url
         $scheme = strtolower($scheme);
 
         // Whitelist always takes precedence over a blacklist
-        if (!$options->isInList('whitelist', 'scheme', $scheme)) {
-            throw new InvalidSchemeException('Provided scheme "' . $scheme . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList('whitelist', 'scheme')));
+        if (!$options->isInList(Options::LIST_WHITELIST, 'scheme', $scheme)) {
+            throw new InvalidSchemeException('Provided scheme "' . $scheme . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, 'scheme')));
         }
 
-        if ($options->isInList('blacklist', 'scheme', $scheme)) {
+        if ($options->isInList(Options::LIST_BLACKLIST, 'scheme', $scheme)) {
             throw new InvalidSchemeException('Provided scheme "' . $scheme . '" matches a blacklisted value');
         }
 
@@ -109,11 +109,11 @@ class Url
     public static function validatePort($port, Options $options)
     {
         $port = (string) $port;
-        if (!$options->isInList('whitelist', 'port', $port)) {
-            throw new InvalidPortException('Provided port "' . $port . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList('whitelist', 'port')));
+        if (!$options->isInList(Options::LIST_WHITELIST, 'port', $port)) {
+            throw new InvalidPortException('Provided port "' . $port . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, 'port')));
         }
 
-        if ($options->isInList('blacklist', 'port', $port)) {
+        if ($options->isInList(Options::LIST_BLACKLIST, 'port', $port)) {
             throw new InvalidPortException('Provided port "' . $port . '" matches a blacklisted value');
         }
 
@@ -136,11 +136,11 @@ class Url
         $host = strtolower($host);
 
         // Check the host against the domain lists
-        if (!$options->isInList('whitelist', 'domain', $host)) {
-            throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList('whitelist', 'domain')));
+        if (!$options->isInList(Options::LIST_WHITELIST, 'domain', $host)) {
+            throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, 'domain')));
         }
 
-        if ($options->isInList('blacklist', 'domain', $host)) {
+        if ($options->isInList(Options::LIST_BLACKLIST, 'domain', $host)) {
             throw new InvalidDomainException('Provided host "' . $host . '" matches a blacklisted value');
         }
 
@@ -150,7 +150,7 @@ class Url
             throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t resolve to an IP address');
         }
 
-        $whitelistedIps = $options->getList('whitelist', 'ip');
+        $whitelistedIps = $options->getList(Options::LIST_WHITELIST, 'ip');
 
         if (!empty($whitelistedIps)) {
             $valid = false;
@@ -169,7 +169,7 @@ class Url
             }
         }
 
-        $blacklistedIps = $options->getList('blacklist', 'ip');
+        $blacklistedIps = $options->getList(Options::LIST_BLACKLIST, 'ip');
 
         if (!empty($blacklistedIps)) {
             foreach ($blacklistedIps as $blacklistedIp) {

--- a/src/Url.php
+++ b/src/Url.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/src/Url.php
+++ b/src/Url.php
@@ -85,11 +85,11 @@ class Url
         $scheme = strtolower($scheme);
 
         // Whitelist always takes precedence over a blacklist
-        if (!$options->isInList(Options::LIST_WHITELIST, 'scheme', $scheme)) {
-            throw new InvalidSchemeException('Provided scheme "' . $scheme . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, 'scheme')));
+        if (!$options->isInList(Options::LIST_WHITELIST, Options::TYPE_SCHEME, $scheme)) {
+            throw new InvalidSchemeException('Provided scheme "' . $scheme . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, Options::TYPE_SCHEME)));
         }
 
-        if ($options->isInList(Options::LIST_BLACKLIST, 'scheme', $scheme)) {
+        if ($options->isInList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME, $scheme)) {
             throw new InvalidSchemeException('Provided scheme "' . $scheme . '" matches a blacklisted value');
         }
 
@@ -109,11 +109,11 @@ class Url
     public static function validatePort($port, Options $options)
     {
         $port = (string) $port;
-        if (!$options->isInList(Options::LIST_WHITELIST, 'port', $port)) {
-            throw new InvalidPortException('Provided port "' . $port . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, 'port')));
+        if (!$options->isInList(Options::LIST_WHITELIST, Options::TYPE_PORT, $port)) {
+            throw new InvalidPortException('Provided port "' . $port . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, Options::TYPE_PORT)));
         }
 
-        if ($options->isInList(Options::LIST_BLACKLIST, 'port', $port)) {
+        if ($options->isInList(Options::LIST_BLACKLIST, Options::TYPE_PORT, $port)) {
             throw new InvalidPortException('Provided port "' . $port . '" matches a blacklisted value');
         }
 
@@ -136,11 +136,11 @@ class Url
         $host = strtolower($host);
 
         // Check the host against the domain lists
-        if (!$options->isInList(Options::LIST_WHITELIST, 'domain', $host)) {
-            throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, 'domain')));
+        if (!$options->isInList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, $host)) {
+            throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t match whitelisted values: ' . implode(', ', $options->getList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN)));
         }
 
-        if ($options->isInList(Options::LIST_BLACKLIST, 'domain', $host)) {
+        if ($options->isInList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN, $host)) {
             throw new InvalidDomainException('Provided host "' . $host . '" matches a blacklisted value');
         }
 
@@ -150,7 +150,7 @@ class Url
             throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t resolve to an IP address');
         }
 
-        $whitelistedIps = $options->getList(Options::LIST_WHITELIST, 'ip');
+        $whitelistedIps = $options->getList(Options::LIST_WHITELIST, Options::TYPE_IP);
 
         if (!empty($whitelistedIps)) {
             $valid = false;
@@ -169,7 +169,7 @@ class Url
             }
         }
 
-        $blacklistedIps = $options->getList(Options::LIST_BLACKLIST, 'ip');
+        $blacklistedIps = $options->getList(Options::LIST_BLACKLIST, Options::TYPE_IP);
 
         if (!empty($blacklistedIps)) {
             foreach ($blacklistedIps as $blacklistedIp) {

--- a/src/Url.php
+++ b/src/Url.php
@@ -13,13 +13,11 @@ class Url
     /**
      * Validates the whole URL.
      *
-     * @param string $url
-     *
      * @throws InvalidURLException
      *
-     * @return array
+     * @return array{url: string, host: string, ips: string[]}
      */
-    public static function validateUrl($url, Options $options)
+    public static function validateUrl(string $url, Options $options): array
     {
         if ('' === trim($url)) {
             throw new InvalidURLException('Provided URL "' . $url . '" cannot be empty');
@@ -74,13 +72,9 @@ class Url
     /**
      * Validates a URL scheme.
      *
-     * @param string $scheme
-     *
      * @throws InvalidSchemeException
-     *
-     * @return string
      */
-    public static function validateScheme($scheme, Options $options)
+    public static function validateScheme(string $scheme, Options $options): string
     {
         $scheme = strtolower($scheme);
 
@@ -103,10 +97,8 @@ class Url
      * @param string|int $port
      *
      * @throws InvalidPortException
-     *
-     * @return string
      */
-    public static function validatePort($port, Options $options)
+    public static function validatePort($port, Options $options): int
     {
         $port = (string) $port;
         if (!$options->isInList(Options::LIST_WHITELIST, Options::TYPE_PORT, $port)) {
@@ -118,20 +110,18 @@ class Url
         }
 
         // Existing value is fine
-        return $port;
+        return (int) $port;
     }
 
     /**
      * Validates a URL host.
      *
-     * @param string $host
-     *
      * @throws InvalidDomainException
      * @throws InvalidIPException
      *
-     * @return array
+     * @return array{host: string, ips: string[]}
      */
-    public static function validateHost($host, Options $options)
+    public static function validateHost(string $host, Options $options): array
     {
         $host = strtolower($host);
 
@@ -190,11 +180,9 @@ class Url
     /**
      * Re-build a URL based on an array of parts.
      *
-     * @param array $parts
-     *
-     * @return string
+     * @param array{scheme?: string, user?: string, pass?: string, host?: string, port?: int, path?: string, query?: string, fragment?: string} $parts
      */
-    public static function buildUrl($parts)
+    public static function buildUrl(array $parts): string
     {
         $url = '';
 
@@ -215,13 +203,8 @@ class Url
     /**
      * Checks a passed in IP against a CIDR.
      * See http://stackoverflow.com/questions/594112/matching-an-ip-to-a-cidr-mask-in-php5.
-     *
-     * @param string $ip
-     * @param string $cidr
-     *
-     * @return bool
      */
-    public static function cidrMatch($ip, $cidr)
+    public static function cidrMatch(string $ip, string $cidr): bool
     {
         if (false === strpos($cidr, '/')) {
             // It doesn't have a prefix, just a straight IP match

--- a/tests/Exception/InvalidOptionExceptionTest.php
+++ b/tests/Exception/InvalidOptionExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidOptionException;

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,8 +7,7 @@ use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Options;
 
 class OptionsTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var Options */
-    private $options;
+    private Options $options;
 
     protected function setUp(): void
     {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -226,7 +226,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided values cannot be empty');
 
-        $this->options->addToList('whitelist', 'ip', null);
+        $this->options->addToList('whitelist', 'ip', []);
     }
 
     public function testRemoveFromListBadList(): void
@@ -250,7 +250,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided values cannot be empty');
 
-        $this->options->removeFromList('whitelist', 'ip', null);
+        $this->options->removeFromList('whitelist', 'ip', []);
     }
 
     public function testRemoveFromList(): void

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -135,7 +135,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(15, $list);
         $this->assertSame('0.0.0.0/8', $list[0]);
 
-        $this->options->addToList('blacklist', 'port', '8080');
+        $this->options->addToList('blacklist', 'port', 8080);
         $list = $this->options->getList('blacklist', 'port');
 
         $this->assertCount(1, $list);
@@ -178,18 +178,18 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->options->setList('blacklist', [22], 'port');
 
-        $this->assertSame([22], $this->options->getList('blacklist', 'port'));
+        $this->assertSame(['22'], $this->options->getList('blacklist', 'port'));
     }
 
     public function testSetListPreservesNonOverlapping(): void
     {
         $this->options->setList('blacklist', ['port' => [1234]]);
-        $this->assertSame([1234], $this->options->getList('blacklist', 'port'));
+        $this->assertSame(['1234'], $this->options->getList('blacklist', 'port'));
 
         $this->options->setList('blacklist', ['ip' => ['0.0.0.0']]);
         $this->assertSame(['0.0.0.0'], $this->options->getList('blacklist', 'ip'));
 
-        $this->assertSame([1234], $this->options->getList('blacklist', 'port'), 'Setting partial list should not override keys that were omitted.');
+        $this->assertSame(['1234'], $this->options->getList('blacklist', 'port'), 'Setting partial list should not override keys that were omitted.');
     }
 
     public function testSetListBadList(): void
@@ -267,13 +267,13 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
     public function testRemoveFromList(): void
     {
         // remove not an array
-        $this->options->addToList('blacklist', 'port', '8080');
+        $this->options->addToList('blacklist', 'port', 8080);
         $list = $this->options->getList('blacklist', 'port');
 
         $this->assertCount(1, $list);
         $this->assertSame('8080', $list[0]);
 
-        $this->options->removeFromList('blacklist', 'port', '8080');
+        $this->options->removeFromList('blacklist', 'port', 8080);
         $list = $this->options->getList('blacklist', 'port');
 
         $this->assertCount(0, $list);
@@ -289,5 +289,20 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $list = $this->options->getList('blacklist', 'scheme');
 
         $this->assertCount(0, $list);
+    }
+
+    public function testNumericPortIsInList(): void
+    {
+        $this->options->addToList('blacklist', 'port', 8080);
+        $this->assertTrue($this->options->isInList('blacklist', 'port', '8080'));
+    }
+
+    public function testInvalidTypeCoverage(): void
+    {
+        // This would be disallowed by static analysis but code coverage complains.
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Option values can only be strings or ints.');
+
+        $this->options->addToList('blacklist', 'port', (object) ['dummy' => true]);
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -181,6 +181,17 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame([22], $this->options->getList('blacklist', 'port'));
     }
 
+    public function testSetListPreservesNonOverlapping(): void
+    {
+        $this->options->setList('blacklist', ['port' => [1234]]);
+        $this->assertSame([1234], $this->options->getList('blacklist', 'port'));
+
+        $this->options->setList('blacklist', ['ip' => ['0.0.0.0']]);
+        $this->assertSame(['0.0.0.0'], $this->options->getList('blacklist', 'ip'));
+
+        $this->assertSame([1234], $this->options->getList('blacklist', 'port'), 'Setting partial list should not override keys that were omitted.');
+    }
+
     public function testSetListBadList(): void
     {
         $this->expectException(InvalidOptionException::class);

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -43,25 +43,25 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testInListEmptyValue(): void
     {
-        $this->assertTrue($this->options->isInList('whitelist', 'ip', ''));
-        $this->assertFalse($this->options->isInList('whitelist', 'port', ''));
-        $this->assertTrue($this->options->isInList('whitelist', 'domain', ''));
-        $this->assertFalse($this->options->isInList('whitelist', 'scheme', ''));
+        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, 'ip', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'port', ''));
+        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, 'domain', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'scheme', ''));
 
-        $this->assertFalse($this->options->isInList('blacklist', 'ip', ''));
-        $this->assertFalse($this->options->isInList('blacklist', 'port', ''));
-        $this->assertFalse($this->options->isInList('blacklist', 'domain', ''));
-        $this->assertFalse($this->options->isInList('blacklist', 'scheme', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'ip', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'port', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'domain', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'scheme', ''));
     }
 
     public function testInListDomainRegex(): void
     {
-        $this->options->addToList('whitelist', 'domain', '(.*)\.fin1te\.net');
+        $this->options->addToList(Options::LIST_WHITELIST, 'domain', '(.*)\.fin1te\.net');
 
-        $this->assertFalse($this->options->isInList('whitelist', 'domain', ''));
-        $this->assertFalse($this->options->isInList('whitelist', 'domain', 'fin1te.net'));
-        $this->assertFalse($this->options->isInList('whitelist', 'domain', 'superfin1te.net'));
-        $this->assertTrue($this->options->isInList('whitelist', 'domain', 'www.fin1te.net'));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'domain', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'domain', 'fin1te.net'));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'domain', 'superfin1te.net'));
+        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, 'domain', 'www.fin1te.net'));
     }
 
     public function testInListBadList(): void
@@ -77,12 +77,12 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
 
-        $this->options->isInList('whitelist', 'noo', '');
+        $this->options->isInList(Options::LIST_WHITELIST, 'noo', '');
     }
 
     public function testGetListWithoutType(): void
     {
-        $list = $this->options->getList('whitelist');
+        $list = $this->options->getList(Options::LIST_WHITELIST);
 
         $this->assertCount(4, $list);
         $this->assertArrayHasKey('ip', $list);
@@ -90,7 +90,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('domain', $list);
         $this->assertArrayHasKey('scheme', $list);
 
-        $list = $this->options->getList('blacklist');
+        $list = $this->options->getList(Options::LIST_BLACKLIST);
 
         $this->assertCount(4, $list);
         $this->assertArrayHasKey('ip', $list);
@@ -101,27 +101,27 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testGetListWhitelistWithType(): void
     {
-        $this->options->addToList('whitelist', 'ip', '0.0.0.0');
-        $list = $this->options->getList('whitelist', 'ip');
+        $this->options->addToList(Options::LIST_WHITELIST, 'ip', '0.0.0.0');
+        $list = $this->options->getList(Options::LIST_WHITELIST, 'ip');
 
         $this->assertCount(1, $list);
         $this->assertArrayHasKey(0, $list);
         $this->assertSame('0.0.0.0', $list[0]);
 
-        $list = $this->options->getList('whitelist', 'port');
+        $list = $this->options->getList(Options::LIST_WHITELIST, 'port');
 
         $this->assertCount(3, $list);
         $this->assertSame('80', $list[0]);
         $this->assertSame('443', $list[1]);
         $this->assertSame('8080', $list[2]);
 
-        $this->options->addToList('whitelist', 'domain', '(.*)\.fin1te\.net');
-        $list = $this->options->getList('whitelist', 'domain');
+        $this->options->addToList(Options::LIST_WHITELIST, 'domain', '(.*)\.fin1te\.net');
+        $list = $this->options->getList(Options::LIST_WHITELIST, 'domain');
 
         $this->assertCount(1, $list);
         $this->assertSame('(.*)\.fin1te\.net', $list[0]);
 
-        $list = $this->options->getList('whitelist', 'scheme');
+        $list = $this->options->getList(Options::LIST_WHITELIST, 'scheme');
 
         $this->assertCount(2, $list);
         $this->assertSame('http', $list[0]);
@@ -130,25 +130,25 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testGetListBlacklistWithType(): void
     {
-        $list = $this->options->getList('blacklist', 'ip');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'ip');
 
         $this->assertCount(15, $list);
         $this->assertSame('0.0.0.0/8', $list[0]);
 
-        $this->options->addToList('blacklist', 'port', 8080);
-        $list = $this->options->getList('blacklist', 'port');
+        $this->options->addToList(Options::LIST_BLACKLIST, 'port', 8080);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'port');
 
         $this->assertCount(1, $list);
         $this->assertSame('8080', $list[0]);
 
-        $this->options->addToList('blacklist', 'domain', '(.*)\.fin1te\.net');
-        $list = $this->options->getList('blacklist', 'domain');
+        $this->options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.fin1te\.net');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'domain');
 
         $this->assertCount(1, $list);
         $this->assertSame('(.*)\.fin1te\.net', $list[0]);
 
-        $this->options->addToList('blacklist', 'scheme', 'ftp');
-        $list = $this->options->getList('blacklist', 'scheme');
+        $this->options->addToList(Options::LIST_BLACKLIST, 'scheme', 'ftp');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'scheme');
 
         $this->assertCount(1, $list);
         $this->assertSame('ftp', $list[0]);
@@ -167,29 +167,29 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
 
-        $this->options->getList('whitelist', 'noo');
+        $this->options->getList(Options::LIST_WHITELIST, 'noo');
     }
 
     public function testSetList(): void
     {
-        $this->options->setList('whitelist', ['ip' => ['0.0.0.0']]);
+        $this->options->setList(Options::LIST_WHITELIST, ['ip' => ['0.0.0.0']]);
 
-        $this->assertSame(['0.0.0.0'], $this->options->getList('whitelist', 'ip'));
+        $this->assertSame(['0.0.0.0'], $this->options->getList(Options::LIST_WHITELIST, 'ip'));
 
-        $this->options->setList('blacklist', [22], 'port');
+        $this->options->setList(Options::LIST_BLACKLIST, [22], 'port');
 
-        $this->assertSame(['22'], $this->options->getList('blacklist', 'port'));
+        $this->assertSame(['22'], $this->options->getList(Options::LIST_BLACKLIST, 'port'));
     }
 
     public function testSetListPreservesNonOverlapping(): void
     {
-        $this->options->setList('blacklist', ['port' => [1234]]);
-        $this->assertSame(['1234'], $this->options->getList('blacklist', 'port'));
+        $this->options->setList(Options::LIST_BLACKLIST, ['port' => [1234]]);
+        $this->assertSame(['1234'], $this->options->getList(Options::LIST_BLACKLIST, 'port'));
 
-        $this->options->setList('blacklist', ['ip' => ['0.0.0.0']]);
-        $this->assertSame(['0.0.0.0'], $this->options->getList('blacklist', 'ip'));
+        $this->options->setList(Options::LIST_BLACKLIST, ['ip' => ['0.0.0.0']]);
+        $this->assertSame(['0.0.0.0'], $this->options->getList(Options::LIST_BLACKLIST, 'ip'));
 
-        $this->assertSame(['1234'], $this->options->getList('blacklist', 'port'), 'Setting partial list should not override keys that were omitted.');
+        $this->assertSame(['1234'], $this->options->getList(Options::LIST_BLACKLIST, 'port'), 'Setting partial list should not override keys that were omitted.');
     }
 
     public function testSetListBadList(): void
@@ -205,7 +205,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
 
-        $this->options->setList('whitelist', [], 'noo');
+        $this->options->setList(Options::LIST_WHITELIST, [], 'noo');
     }
 
     public function testSetListBadTypeValue(): void
@@ -213,7 +213,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
 
-        $this->options->setList('whitelist', ['noo' => 'oops']);
+        $this->options->setList(Options::LIST_WHITELIST, ['noo' => 'oops']);
     }
 
     public function testAddToListBadList(): void
@@ -229,7 +229,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
 
-        $this->options->addToList('whitelist', 'noo', 'noo');
+        $this->options->addToList(Options::LIST_WHITELIST, 'noo', 'noo');
     }
 
     public function testAddToListBadValue(): void
@@ -237,7 +237,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided values cannot be empty');
 
-        $this->options->addToList('whitelist', 'ip', []);
+        $this->options->addToList(Options::LIST_WHITELIST, 'ip', []);
     }
 
     public function testRemoveFromListBadList(): void
@@ -253,7 +253,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
 
-        $this->options->removeFromList('whitelist', 'noo', 'noo');
+        $this->options->removeFromList(Options::LIST_WHITELIST, 'noo', 'noo');
     }
 
     public function testRemoveFromListBadValue(): void
@@ -261,40 +261,40 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided values cannot be empty');
 
-        $this->options->removeFromList('whitelist', 'ip', []);
+        $this->options->removeFromList(Options::LIST_WHITELIST, 'ip', []);
     }
 
     public function testRemoveFromList(): void
     {
         // remove not an array
-        $this->options->addToList('blacklist', 'port', 8080);
-        $list = $this->options->getList('blacklist', 'port');
+        $this->options->addToList(Options::LIST_BLACKLIST, 'port', 8080);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'port');
 
         $this->assertCount(1, $list);
         $this->assertSame('8080', $list[0]);
 
-        $this->options->removeFromList('blacklist', 'port', 8080);
-        $list = $this->options->getList('blacklist', 'port');
+        $this->options->removeFromList(Options::LIST_BLACKLIST, 'port', 8080);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'port');
 
         $this->assertCount(0, $list);
 
         // remove using an array
-        $this->options->addToList('blacklist', 'scheme', 'ftp');
-        $list = $this->options->getList('blacklist', 'scheme');
+        $this->options->addToList(Options::LIST_BLACKLIST, 'scheme', 'ftp');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'scheme');
 
         $this->assertCount(1, $list);
         $this->assertSame('ftp', $list[0]);
 
-        $this->options->removeFromList('blacklist', 'scheme', ['ftp']);
-        $list = $this->options->getList('blacklist', 'scheme');
+        $this->options->removeFromList(Options::LIST_BLACKLIST, 'scheme', ['ftp']);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, 'scheme');
 
         $this->assertCount(0, $list);
     }
 
     public function testNumericPortIsInList(): void
     {
-        $this->options->addToList('blacklist', 'port', 8080);
-        $this->assertTrue($this->options->isInList('blacklist', 'port', '8080'));
+        $this->options->addToList(Options::LIST_BLACKLIST, 'port', 8080);
+        $this->assertTrue($this->options->isInList(Options::LIST_BLACKLIST, 'port', '8080'));
     }
 
     public function testInvalidTypeCoverage(): void
@@ -303,6 +303,6 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Option values can only be strings or ints.');
 
-        $this->options->addToList('blacklist', 'port', (object) ['dummy' => true]);
+        $this->options->addToList(Options::LIST_BLACKLIST, 'port', (object) ['dummy' => true]);
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidOptionException;

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -43,25 +43,25 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testInListEmptyValue(): void
     {
-        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, 'ip', ''));
-        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'port', ''));
-        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, 'domain', ''));
-        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'scheme', ''));
+        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_IP, ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_PORT, ''));
+        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_SCHEME, ''));
 
-        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'ip', ''));
-        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'port', ''));
-        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'domain', ''));
-        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, 'scheme', ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, Options::TYPE_IP, ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, Options::TYPE_PORT, ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN, ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME, ''));
     }
 
     public function testInListDomainRegex(): void
     {
-        $this->options->addToList(Options::LIST_WHITELIST, 'domain', '(.*)\.fin1te\.net');
+        $this->options->addToList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, '(.*)\.fin1te\.net');
 
-        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'domain', ''));
-        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'domain', 'fin1te.net'));
-        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, 'domain', 'superfin1te.net'));
-        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, 'domain', 'www.fin1te.net'));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, ''));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, 'fin1te.net'));
+        $this->assertFalse($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, 'superfin1te.net'));
+        $this->assertTrue($this->options->isInList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, 'www.fin1te.net'));
     }
 
     public function testInListBadList(): void
@@ -85,43 +85,43 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $list = $this->options->getList(Options::LIST_WHITELIST);
 
         $this->assertCount(4, $list);
-        $this->assertArrayHasKey('ip', $list);
-        $this->assertArrayHasKey('port', $list);
-        $this->assertArrayHasKey('domain', $list);
-        $this->assertArrayHasKey('scheme', $list);
+        $this->assertArrayHasKey(Options::TYPE_IP, $list);
+        $this->assertArrayHasKey(Options::TYPE_PORT, $list);
+        $this->assertArrayHasKey(Options::TYPE_DOMAIN, $list);
+        $this->assertArrayHasKey(Options::TYPE_SCHEME, $list);
 
         $list = $this->options->getList(Options::LIST_BLACKLIST);
 
         $this->assertCount(4, $list);
-        $this->assertArrayHasKey('ip', $list);
-        $this->assertArrayHasKey('port', $list);
-        $this->assertArrayHasKey('domain', $list);
-        $this->assertArrayHasKey('scheme', $list);
+        $this->assertArrayHasKey(Options::TYPE_IP, $list);
+        $this->assertArrayHasKey(Options::TYPE_PORT, $list);
+        $this->assertArrayHasKey(Options::TYPE_DOMAIN, $list);
+        $this->assertArrayHasKey(Options::TYPE_SCHEME, $list);
     }
 
     public function testGetListWhitelistWithType(): void
     {
-        $this->options->addToList(Options::LIST_WHITELIST, 'ip', '0.0.0.0');
-        $list = $this->options->getList(Options::LIST_WHITELIST, 'ip');
+        $this->options->addToList(Options::LIST_WHITELIST, Options::TYPE_IP, '0.0.0.0');
+        $list = $this->options->getList(Options::LIST_WHITELIST, Options::TYPE_IP);
 
         $this->assertCount(1, $list);
         $this->assertArrayHasKey(0, $list);
         $this->assertSame('0.0.0.0', $list[0]);
 
-        $list = $this->options->getList(Options::LIST_WHITELIST, 'port');
+        $list = $this->options->getList(Options::LIST_WHITELIST, Options::TYPE_PORT);
 
         $this->assertCount(3, $list);
         $this->assertSame('80', $list[0]);
         $this->assertSame('443', $list[1]);
         $this->assertSame('8080', $list[2]);
 
-        $this->options->addToList(Options::LIST_WHITELIST, 'domain', '(.*)\.fin1te\.net');
-        $list = $this->options->getList(Options::LIST_WHITELIST, 'domain');
+        $this->options->addToList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, '(.*)\.fin1te\.net');
+        $list = $this->options->getList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN);
 
         $this->assertCount(1, $list);
         $this->assertSame('(.*)\.fin1te\.net', $list[0]);
 
-        $list = $this->options->getList(Options::LIST_WHITELIST, 'scheme');
+        $list = $this->options->getList(Options::LIST_WHITELIST, Options::TYPE_SCHEME);
 
         $this->assertCount(2, $list);
         $this->assertSame('http', $list[0]);
@@ -130,25 +130,25 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testGetListBlacklistWithType(): void
     {
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'ip');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_IP);
 
         $this->assertCount(15, $list);
         $this->assertSame('0.0.0.0/8', $list[0]);
 
-        $this->options->addToList(Options::LIST_BLACKLIST, 'port', 8080);
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'port');
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_PORT, 8080);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_PORT);
 
         $this->assertCount(1, $list);
         $this->assertSame('8080', $list[0]);
 
-        $this->options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.fin1te\.net');
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'domain');
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN, '(.*)\.fin1te\.net');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN);
 
         $this->assertCount(1, $list);
         $this->assertSame('(.*)\.fin1te\.net', $list[0]);
 
-        $this->options->addToList(Options::LIST_BLACKLIST, 'scheme', 'ftp');
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'scheme');
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME, 'ftp');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME);
 
         $this->assertCount(1, $list);
         $this->assertSame('ftp', $list[0]);
@@ -172,24 +172,24 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testSetList(): void
     {
-        $this->options->setList(Options::LIST_WHITELIST, ['ip' => ['0.0.0.0']]);
+        $this->options->setList(Options::LIST_WHITELIST, [Options::TYPE_IP => ['0.0.0.0']]);
 
-        $this->assertSame(['0.0.0.0'], $this->options->getList(Options::LIST_WHITELIST, 'ip'));
+        $this->assertSame(['0.0.0.0'], $this->options->getList(Options::LIST_WHITELIST, Options::TYPE_IP));
 
-        $this->options->setList(Options::LIST_BLACKLIST, [22], 'port');
+        $this->options->setList(Options::LIST_BLACKLIST, [22], Options::TYPE_PORT);
 
-        $this->assertSame(['22'], $this->options->getList(Options::LIST_BLACKLIST, 'port'));
+        $this->assertSame(['22'], $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_PORT));
     }
 
     public function testSetListPreservesNonOverlapping(): void
     {
-        $this->options->setList(Options::LIST_BLACKLIST, ['port' => [1234]]);
-        $this->assertSame(['1234'], $this->options->getList(Options::LIST_BLACKLIST, 'port'));
+        $this->options->setList(Options::LIST_BLACKLIST, [Options::TYPE_PORT => [1234]]);
+        $this->assertSame(['1234'], $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_PORT));
 
-        $this->options->setList(Options::LIST_BLACKLIST, ['ip' => ['0.0.0.0']]);
-        $this->assertSame(['0.0.0.0'], $this->options->getList(Options::LIST_BLACKLIST, 'ip'));
+        $this->options->setList(Options::LIST_BLACKLIST, [Options::TYPE_IP => ['0.0.0.0']]);
+        $this->assertSame(['0.0.0.0'], $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_IP));
 
-        $this->assertSame(['1234'], $this->options->getList(Options::LIST_BLACKLIST, 'port'), 'Setting partial list should not override keys that were omitted.');
+        $this->assertSame(['1234'], $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_PORT), 'Setting partial list should not override keys that were omitted.');
     }
 
     public function testSetListBadList(): void
@@ -237,7 +237,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided values cannot be empty');
 
-        $this->options->addToList(Options::LIST_WHITELIST, 'ip', []);
+        $this->options->addToList(Options::LIST_WHITELIST, Options::TYPE_IP, []);
     }
 
     public function testRemoveFromListBadList(): void
@@ -261,40 +261,40 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Provided values cannot be empty');
 
-        $this->options->removeFromList(Options::LIST_WHITELIST, 'ip', []);
+        $this->options->removeFromList(Options::LIST_WHITELIST, Options::TYPE_IP, []);
     }
 
     public function testRemoveFromList(): void
     {
         // remove not an array
-        $this->options->addToList(Options::LIST_BLACKLIST, 'port', 8080);
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'port');
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_PORT, 8080);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_PORT);
 
         $this->assertCount(1, $list);
         $this->assertSame('8080', $list[0]);
 
-        $this->options->removeFromList(Options::LIST_BLACKLIST, 'port', 8080);
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'port');
+        $this->options->removeFromList(Options::LIST_BLACKLIST, Options::TYPE_PORT, 8080);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_PORT);
 
         $this->assertCount(0, $list);
 
         // remove using an array
-        $this->options->addToList(Options::LIST_BLACKLIST, 'scheme', 'ftp');
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'scheme');
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME, 'ftp');
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME);
 
         $this->assertCount(1, $list);
         $this->assertSame('ftp', $list[0]);
 
-        $this->options->removeFromList(Options::LIST_BLACKLIST, 'scheme', ['ftp']);
-        $list = $this->options->getList(Options::LIST_BLACKLIST, 'scheme');
+        $this->options->removeFromList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME, ['ftp']);
+        $list = $this->options->getList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME);
 
         $this->assertCount(0, $list);
     }
 
     public function testNumericPortIsInList(): void
     {
-        $this->options->addToList(Options::LIST_BLACKLIST, 'port', 8080);
-        $this->assertTrue($this->options->isInList(Options::LIST_BLACKLIST, 'port', '8080'));
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_PORT, 8080);
+        $this->assertTrue($this->options->isInList(Options::LIST_BLACKLIST, Options::TYPE_PORT, '8080'));
     }
 
     public function testInvalidTypeCoverage(): void
@@ -303,6 +303,6 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Option values can only be strings or ints.');
 
-        $this->options->addToList(Options::LIST_BLACKLIST, 'port', (object) ['dummy' => true]);
+        $this->options->addToList(Options::LIST_BLACKLIST, Options::TYPE_PORT, (object) ['dummy' => true]);
     }
 }

--- a/tests/ServerSideRequestForgeryProtectionPluginTest.php
+++ b/tests/ServerSideRequestForgeryProtectionPluginTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Options;

--- a/tests/ServerSideRequestForgeryProtectionPluginTest.php
+++ b/tests/ServerSideRequestForgeryProtectionPluginTest.php
@@ -6,19 +6,25 @@ namespace Tests\Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Options;
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\ServerSideRequestForgeryProtectionPlugin;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\Exception\RequestException;
-use Http\Mock\Client;
 
 class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\TestCase
 {
     public function testGet(): void
     {
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin()]);
 
         $response = $client->sendRequest(new Request('GET', 'http://www.google.com'));
@@ -55,8 +61,12 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $this->expectException(RequestException::class);
         $this->expectExceptionMessage($message);
 
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin()]);
 
         $client->sendRequest(new Request('GET', $url));
@@ -86,8 +96,12 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $options->addToList(Options::LIST_WHITELIST, 'scheme', 'ftp');
         $options->disableSendCredentials();
 
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin($options)]);
 
         $client->sendRequest(new Request('GET', $url));
@@ -98,8 +112,12 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $options = new Options();
         $options->enablePinDns();
 
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin($options)]);
 
         $response = $client->sendRequest(new Request('GET', 'http://google.com'));
@@ -113,9 +131,13 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $this->expectExceptionMessage('Provided port "123" doesn\'t match whitelisted values: 80, 443, 8080');
 
         $options = new Options();
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(301, ['Location' => 'http://0.0.0.0:123/']));
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(301, ['Location' => 'http://0.0.0.0:123/']),
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [
             new ServerSideRequestForgeryProtectionPlugin($options),
             new RedirectPlugin(),
@@ -126,8 +148,12 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
 
     public function testAsyncGet(): void
     {
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin()]);
 
         $promise = $client->sendAsyncRequest(new Request('GET', 'http://www.google.com'))->then(
@@ -146,8 +172,12 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $url = 'http://0.0.0.0:123';
         $message = 'Provided port "123" doesn\'t match whitelisted values: 80, 443, 8080';
 
-        $mockClient = new Client();
-        $mockClient->addResponse(new Response(200));
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $mockClient = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+        ]);
         $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin()]);
 
         $promise = $client->sendAsyncRequest(new Request('GET', $url));

--- a/tests/ServerSideRequestForgeryProtectionPluginTest.php
+++ b/tests/ServerSideRequestForgeryProtectionPluginTest.php
@@ -74,8 +74,8 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $this->expectExceptionMessage($message);
 
         $options = new Options();
-        $options->addToList('blacklist', 'domain', '(.*)\.fin1te\.net');
-        $options->addToList('whitelist', 'scheme', 'ftp');
+        $options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.fin1te\.net');
+        $options->addToList(Options::LIST_WHITELIST, 'scheme', 'ftp');
         $options->disableSendCredentials();
 
         $mockClient = new Client();

--- a/tests/ServerSideRequestForgeryProtectionPluginTest.php
+++ b/tests/ServerSideRequestForgeryProtectionPluginTest.php
@@ -25,6 +25,9 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $this->assertSame(200, $response->getStatusCode());
     }
 
+    /**
+     * @return array<array{string, string}>
+     */
     public function dataForBlockedUrl(): array
     {
         return [
@@ -57,6 +60,9 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $client->sendRequest(new Request('GET', $url));
     }
 
+    /**
+     * @return array<array{string, string}>
+     */
     public function dataForBlockedUrlByOptions(): array
     {
         return [

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -12,6 +12,9 @@ use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Url;
 
 class UrlTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @return array<array{string, class-string<\Exception>, string}>
+     */
     public function dataForValidate(): array
     {
         return [

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -44,7 +44,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided scheme "http" matches a blacklisted value');
 
         $options = new Options();
-        $options->addToList(Options::LIST_BLACKLIST, 'scheme', 'http');
+        $options->addToList(Options::LIST_BLACKLIST, Options::TYPE_SCHEME, 'http');
 
         Url::validateUrl('http://www.fin1te.net', $options);
     }
@@ -55,7 +55,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided port "8080" matches a blacklisted value');
 
         $options = new Options();
-        $options->addToList(Options::LIST_BLACKLIST, 'port', '8080');
+        $options->addToList(Options::LIST_BLACKLIST, Options::TYPE_PORT, '8080');
 
         Url::validateUrl('http://www.fin1te.net:8080', $options);
     }
@@ -66,7 +66,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "www.fin1te.net" matches a blacklisted value');
 
         $options = new Options();
-        $options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.fin1te\.net');
+        $options->addToList(Options::LIST_BLACKLIST, Options::TYPE_DOMAIN, '(.*)\.fin1te\.net');
 
         Url::validateUrl('http://www.fin1te.net', $options);
     }
@@ -77,7 +77,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "www.google.fr" doesn\'t match whitelisted values: (.*)\.fin1te\.net');
 
         $options = new Options();
-        $options->addToList(Options::LIST_WHITELIST, 'domain', '(.*)\.fin1te\.net');
+        $options->addToList(Options::LIST_WHITELIST, Options::TYPE_DOMAIN, '(.*)\.fin1te\.net');
 
         Url::validateUrl('http://www.google.fr', $options);
     }
@@ -98,7 +98,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "2.2.2.2" resolves to "2.2.2.2", which doesn\'t match whitelisted values: 1.1.1.1');
 
         $options = new Options();
-        $options->addToList(Options::LIST_WHITELIST, 'ip', '1.1.1.1');
+        $options->addToList(Options::LIST_WHITELIST, Options::TYPE_IP, '1.1.1.1');
 
         Url::validateUrl('http://2.2.2.2', $options);
     }
@@ -106,7 +106,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     public function testValidateHostWithWhitelistIpOk(): void
     {
         $options = new Options();
-        $options->addToList(Options::LIST_WHITELIST, 'ip', '1.1.1.1');
+        $options->addToList(Options::LIST_WHITELIST, Options::TYPE_IP, '1.1.1.1');
 
         $res = Url::validateUrl('http://1.1.1.1', $options);
 
@@ -123,7 +123,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "1.1.1.1" resolves to "1.1.1.1", which matches a blacklisted value: 1.1.1.1');
 
         $options = new Options();
-        $options->addToList(Options::LIST_BLACKLIST, 'ip', '1.1.1.1');
+        $options->addToList(Options::LIST_BLACKLIST, Options::TYPE_IP, '1.1.1.1');
 
         Url::validateUrl('http://1.1.1.1', $options);
     }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Exception\InvalidURLException;

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -44,7 +44,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided scheme "http" matches a blacklisted value');
 
         $options = new Options();
-        $options->addToList('blacklist', 'scheme', 'http');
+        $options->addToList(Options::LIST_BLACKLIST, 'scheme', 'http');
 
         Url::validateUrl('http://www.fin1te.net', $options);
     }
@@ -55,7 +55,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided port "8080" matches a blacklisted value');
 
         $options = new Options();
-        $options->addToList('blacklist', 'port', '8080');
+        $options->addToList(Options::LIST_BLACKLIST, 'port', '8080');
 
         Url::validateUrl('http://www.fin1te.net:8080', $options);
     }
@@ -66,7 +66,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "www.fin1te.net" matches a blacklisted value');
 
         $options = new Options();
-        $options->addToList('blacklist', 'domain', '(.*)\.fin1te\.net');
+        $options->addToList(Options::LIST_BLACKLIST, 'domain', '(.*)\.fin1te\.net');
 
         Url::validateUrl('http://www.fin1te.net', $options);
     }
@@ -77,7 +77,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "www.google.fr" doesn\'t match whitelisted values: (.*)\.fin1te\.net');
 
         $options = new Options();
-        $options->addToList('whitelist', 'domain', '(.*)\.fin1te\.net');
+        $options->addToList(Options::LIST_WHITELIST, 'domain', '(.*)\.fin1te\.net');
 
         Url::validateUrl('http://www.google.fr', $options);
     }
@@ -98,7 +98,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "2.2.2.2" resolves to "2.2.2.2", which doesn\'t match whitelisted values: 1.1.1.1');
 
         $options = new Options();
-        $options->addToList('whitelist', 'ip', '1.1.1.1');
+        $options->addToList(Options::LIST_WHITELIST, 'ip', '1.1.1.1');
 
         Url::validateUrl('http://2.2.2.2', $options);
     }
@@ -106,7 +106,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     public function testValidateHostWithWhitelistIpOk(): void
     {
         $options = new Options();
-        $options->addToList('whitelist', 'ip', '1.1.1.1');
+        $options->addToList(Options::LIST_WHITELIST, 'ip', '1.1.1.1');
 
         $res = Url::validateUrl('http://1.1.1.1', $options);
 
@@ -123,7 +123,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Provided host "1.1.1.1" resolves to "1.1.1.1", which matches a blacklisted value: 1.1.1.1');
 
         $options = new Options();
-        $options->addToList('blacklist', 'ip', '1.1.1.1');
+        $options->addToList(Options::LIST_BLACKLIST, 'ip', '1.1.1.1');
 
         Url::validateUrl('http://1.1.1.1', $options);
     }


### PR DESCRIPTION
Use typehints over PHPDoc annotations where possible, add more descriptive type annotations, raise PHPStan level.