### PR TITLE
Fix DNS pinning

### DIFF
--- a/src/MockNameResolver.php
+++ b/src/MockNameResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
+
+final class MockNameResolver implements NameResolver
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $hosts;
+
+    /**
+     * @param array<string, string> $hosts
+     */
+    public function __construct(array $hosts)
+    {
+        $this->hosts = $hosts;
+    }
+
+    public function resolve(string $hostname): array
+    {
+        return isset($this->hosts[$hostname]) ? [$this->hosts[$hostname]] : [];
+    }
+}

--- a/src/NameResolver.php
+++ b/src/NameResolver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
+
+interface NameResolver
+{
+    /**
+     * @return list<string>
+     */
+    public function resolve(string $host): array;
+}

--- a/src/NativeNameResolver.php
+++ b/src/NativeNameResolver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
+
+final class NativeNameResolver implements NameResolver
+{
+    public function resolve(string $hostname): array
+    {
+        $ips = @gethostbynamel($hostname);
+
+        if (false === $ips) {
+            return [];
+        }
+
+        return $ips;
+    }
+}

--- a/src/ServerSideRequestForgeryProtectionPlugin.php
+++ b/src/ServerSideRequestForgeryProtectionPlugin.php
@@ -22,11 +22,16 @@ class ServerSideRequestForgeryProtectionPlugin implements Plugin
 {
     private Options $options;
     private UriFactoryInterface $uriFactory;
+    private NameResolver $resolver;
 
-    public function __construct(?Options $options = null, ?UriFactoryInterface $uriFactory = null)
-    {
+    public function __construct(
+        ?Options $options = null,
+        ?UriFactoryInterface $uriFactory = null,
+        ?NameResolver $resolver = null
+    ) {
         $this->options = $options ?: new Options();
         $this->uriFactory = $uriFactory ?: Psr17FactoryDiscovery::findUriFactory();
+        $this->resolver = $resolver ?? new NativeNameResolver();
     }
 
     /**
@@ -36,7 +41,7 @@ class ServerSideRequestForgeryProtectionPlugin implements Plugin
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         try {
-            $urlData = Url::validateUrl((string) $request->getUri(), $this->options);
+            $urlData = Url::validateUrl((string) $request->getUri(), $this->options, $this->resolver);
         } catch (InvalidURLException $e) {
             return new HttpRejectedPromise(new RequestException($e->getMessage(), $request, $e));
         }

--- a/src/ServerSideRequestForgeryProtectionPlugin.php
+++ b/src/ServerSideRequestForgeryProtectionPlugin.php
@@ -49,7 +49,7 @@ class ServerSideRequestForgeryProtectionPlugin implements Plugin
         $uri = $this->uriFactory->createUri($urlData['url']);
 
         if ((string) $uri !== (string) $request->getUri()) {
-            $request = $request->withUri($uri->withHost($urlData['host']));
+            $request = $request->withUri($uri, true);
         }
 
         return $next($request);

--- a/src/Url.php
+++ b/src/Url.php
@@ -17,8 +17,12 @@ class Url
      *
      * @return array{url: string, host: string, ips: string[]}
      */
-    public static function validateUrl(string $url, Options $options): array
+    public static function validateUrl(string $url, Options $options, ?NameResolver $resolver = null): array
     {
+        if (null === $resolver) {
+            $resolver = new NativeNameResolver();
+        }
+
         if ('' === trim($url)) {
             throw new InvalidURLException('Provided URL "' . $url . '" cannot be empty');
         }
@@ -51,7 +55,7 @@ class Url
         }
 
         // Validate the host
-        $host = self::validateHost($parts['host'], $options);
+        $host = self::validateHost($parts['host'], $options, $resolver);
         $parts['host'] = $host['host'];
         if ($options->getPinDns()) {
             // Since we're pinning DNS, we replace the host in the URL
@@ -121,8 +125,12 @@ class Url
      *
      * @return array{host: string, ips: string[]}
      */
-    public static function validateHost(string $host, Options $options): array
+    public static function validateHost(string $host, Options $options, ?NameResolver $resolver = null): array
     {
+        if (null === $resolver) {
+            $resolver = new NativeNameResolver();
+        }
+
         $host = strtolower($host);
 
         // Check the host against the domain lists
@@ -135,8 +143,8 @@ class Url
         }
 
         // Now resolve to an IP and check against the IP lists
-        $ips = @gethostbynamel($host);
-        if (empty($ips)) {
+        $ips = $resolver->resolve($host);
+        if ([] === $ips) {
             throw new InvalidDomainException('Provided host "' . $host . '" doesn\'t resolve to an IP address');
         }
 

--- a/tests/ServerSideRequestForgeryProtectionPluginTest.php
+++ b/tests/ServerSideRequestForgeryProtectionPluginTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection;
 
+use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\MockNameResolver;
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\Options;
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\ServerSideRequestForgeryProtectionPlugin;
 use GuzzleHttp\Client;
@@ -9,12 +10,16 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\Exception\RequestException;
+use Http\Promise\Promise;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\TestCase
+class ServerSideRequestForgeryProtectionPluginTest extends TestCase
 {
     public function testGet(): void
     {
@@ -111,13 +116,45 @@ class ServerSideRequestForgeryProtectionPluginTest extends \PHPUnit\Framework\Te
         $options = new Options();
         $options->enablePinDns();
 
+        $mockResolver = new MockNameResolver([
+            'google.com' => '1.2.3.4',
+        ]);
+
         $mockHandler = new MockHandler([
             new Response(200),
         ]);
         $mockClient = new Client([
             'handler' => HandlerStack::create($mockHandler),
         ]);
-        $client = new PluginClient($mockClient, [new ServerSideRequestForgeryProtectionPlugin($options)]);
+        $client = new PluginClient(
+            $mockClient,
+            [
+                new ServerSideRequestForgeryProtectionPlugin($options, null, $mockResolver),
+                new class($this) implements Plugin {
+                    private TestCase $test;
+
+                    public function __construct(TestCase $test)
+                    {
+                        $this->test = $test;
+                    }
+
+                    /**
+                     * @param callable(RequestInterface): Promise $next
+                     * @param callable(RequestInterface): Promise $first
+                     */
+                    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+                    {
+                        $uri = (string) $request->getUri();
+                        $this->test->assertSame('http://1.2.3.4', $uri, 'IP has not been pinned');
+
+                        $host = $request->getHeaderLine('Host');
+                        $this->test->assertSame('google.com', $host, 'Host header has not been updated');
+
+                        return $next($request);
+                    }
+                },
+            ]
+        );
 
         $response = $client->sendRequest(new Request('GET', 'http://google.com'));
 


### PR DESCRIPTION
Previously, the pinning would create a pinned URI but then overwrite the resolved IP address in its host part with the original host, reverting the pinning. This was the case since the beginning (504a338b7028486e406f170065aa37e103f51da4).

Not sure why the original `uri` had the `host` part replaced. I thought it might have been to set the `Host` header but any PSR-7 implementation should have already been setting that:

https://www.php-fig.org/psr/psr-7/#host-header
> During construction, implementations MUST attempt to set the Host header from a provided URI if no Host header is provided.

And then, the `Request-URI` would remain unpinned.

Let’s replace it while keeping the `Host` header.
If it is set to a different value, it has probably been done intentionally.

Also test that the headers are properly updated. This required introducing a DNS resolver abstraction.
